### PR TITLE
Preserve both arguments of original before function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,9 @@ class ErrorOverlayPlugin {
     compiler.hooks.afterResolvers.tap(className, ({ options }) => {
       if (options.devServer) {
         const originalBefore = options.devServer.before
-        options.devServer.before = app => {
+        options.devServer.before = (app, server) => {
           if (originalBefore) {
-            originalBefore(app)
+            originalBefore(app, server)
           }
           app.use(errorOverlayMiddleware())
         }


### PR DESCRIPTION
The `options.devServer.before` feature accepts two arguments. Unfortunately we're currently throwing one away. This fixes that.

https://webpack.js.org/configuration/dev-server/#devserver-before